### PR TITLE
Adds backURL helper on the tags

### DIFF
--- a/tags/back_url.go
+++ b/tags/back_url.go
@@ -1,0 +1,26 @@
+package tags
+
+import (
+	"net/http"
+
+	"github.com/gobuffalo/helpers/hctx"
+)
+
+// BackURL returns a URL to the referer, if its presend in the
+// "Referer" header it will take it from there. Otherwise it will return
+// "javascript:history.back()" and rely on the browser history.
+func BackURL(help hctx.HelperContext) string {
+	backURL := "javascript:history.back()"
+
+	var req *http.Request
+	var ok bool
+	if req, ok = help.Value("request").(*http.Request); !ok {
+		return backURL
+	}
+
+	if referer := req.Header.Get("Referer"); referer != "" {
+		backURL = referer
+	}
+
+	return backURL
+}

--- a/tags/back_url_test.go
+++ b/tags/back_url_test.go
@@ -1,0 +1,37 @@
+package tags
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gobuffalo/helpers/helptest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackURL(t *testing.T) {
+
+	req, _ := http.NewRequest("GET", "https://wawand.co/contact", nil)
+	req.Header.Add("Referer", "https://gobuffalo.io")
+
+	req2, _ := http.NewRequest("GET", "https://wawand.co/contact", nil)
+
+	testCases := []struct {
+		name        string
+		request     interface{}
+		expectedURL string
+	}{
+		{name: "RefererIncluded", request: req, expectedURL: "https://gobuffalo.io"},
+		{name: "RequestNotRequest", request: "not-request", expectedURL: "javascript:history.back()"},
+		{name: "RequestNotRequest", request: req2, expectedURL: "javascript:history.back()"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(st *testing.T) {
+			c := helptest.NewContext()
+			c.Set("request", testCase.request)
+
+			r := require.New(st)
+			r.Equal(testCase.expectedURL, BackURL(c))
+		})
+	}
+}

--- a/tags/tags.go
+++ b/tags/tags.go
@@ -9,6 +9,7 @@ const (
 	JSKey           = "javascriptTag"
 	LinkToKey       = "linkTo"
 	RemoteLinkToKey = "remoteLinkTo"
+	BackURLKey      = "backURL"
 )
 
 // New returns a map of the helpers within this package.
@@ -24,5 +25,6 @@ func New() hctx.Map {
 		JSKey:           JS,
 		LinkToKey:       LinkTo,
 		RemoteLinkToKey: RemoteLinkTo,
+		BackURLKey:      BackURL,
 	}
 }


### PR DESCRIPTION
This adds `backURL` helper. Which will allow to do things like `linkTo(backURL())` that will be very helpful when we want to have a link to the referer. Hope you like it. 