### PR TITLE
Upgrade Plush & add Update fn to hctx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/gobuffalo/flect v1.0.2
 	github.com/gobuffalo/github_flavored_markdown v1.1.3
-	github.com/gobuffalo/plush/v5 v5.0.3
+	github.com/gobuffalo/plush/v5 v5.0.4
 	github.com/gobuffalo/tags/v3 v3.1.4
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA
 github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gobuffalo/github_flavored_markdown v1.1.3 h1:rSMPtx9ePkFB22vJ+dH+m/EUBS8doQ3S8LeEXcdwZHk=
 github.com/gobuffalo/github_flavored_markdown v1.1.3/go.mod h1:IzgO5xS6hqkDmUh91BW/+Qxo/qYnvfzoz3A7uLkg77I=
-github.com/gobuffalo/plush/v5 v5.0.3 h1:cDt5mQbt+0vpbF+My/9uuk9yB0HFlDzPRE9nHh+vDMA=
-github.com/gobuffalo/plush/v5 v5.0.3/go.mod h1:C08u/VEqzzPBXFF/yqs40P/5Cvc/zlZsMzhCxXyWJmU=
+github.com/gobuffalo/plush/v5 v5.0.4 h1:GgKm+EqqV8QEn1K49b26OKCW7DMJEpw5EIHvy48FHpM=
+github.com/gobuffalo/plush/v5 v5.0.4/go.mod h1:C08u/VEqzzPBXFF/yqs40P/5Cvc/zlZsMzhCxXyWJmU=
 github.com/gobuffalo/tags/v3 v3.1.4 h1:X/ydLLPhgXV4h04Hp2xlbI2oc5MDaa7eub6zw8oHjsM=
 github.com/gobuffalo/tags/v3 v3.1.4/go.mod h1:ArRNo3ErlHO8BtdA0REaZxijuWnWzF6PUXngmMXd2I0=
 github.com/gobuffalo/validate/v3 v3.3.3 h1:o7wkIGSvZBYBd6ChQoLxkz2y1pfmhbI4jNJYh6PuNJ4=

--- a/helptest/context.go
+++ b/helptest/context.go
@@ -59,6 +59,13 @@ func (f *HelperContext) Set(key string, value interface{}) {
 	f.data.Store(key, value)
 }
 
+func (f *HelperContext) Update(key string, value interface{}) bool {
+	if f.Has(key) {
+		f.Set(key, value)
+	}
+	return false
+}
+
 func (f HelperContext) Block() (string, error) {
 	if f.BlockFn == nil {
 		return "", errors.New("no block given")


### PR DESCRIPTION
1. Upgrading Plush to V5.0.4
2. Adding `Update` to make `helpetest/context.go` interface compatible with the latest changes to hctx in Plush